### PR TITLE
Bug fix in tsne kl_divergence  issue #9711

### DIFF
--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -158,8 +158,8 @@ def _kl_divergence(params, P, degrees_of_freedom, n_samples, n_components,
 
     # Q is a heavy-tailed distribution: Student's t-distribution
     dist = pdist(X_embedded, "sqeuclidean")
-    dist += 1.
     dist /= degrees_of_freedom
+    dist += 1.
     dist **= (degrees_of_freedom + 1.0) / -2.0
     Q = np.maximum(dist / (2.0 * np.sum(dist)), MACHINE_EPSILON)
 


### PR DESCRIPTION
Kl_divergence had a small bug and did not follow the correct formula for the t-student probability distribution. Large error would be induced for large n_components.

The correct formula for t-student probability distribution function is, according to wikipedia:
https://en.wikipedia.org/wiki/Student%27s_t-distribution
(gamma((v+1)/2)/gamma(sqrt(v*pi)*gamma(v/2)) * (1+(t^2)/v)^(-(v+1)/2)
= constant * (1+(t^2)/v)^(-(v+1)/2)
where v = degrees of freedom and t-sne uses the pairwise distances as the variable t. We can ignore the constant because it doesn't depend on t and it will be normalized away. The code, however is computing (1/v + (t^2)/v)^(-(v+1)/2).